### PR TITLE
changing from isUserLogInfo to UserLogInfo

### DIFF
--- a/dropbox/common/types.go
+++ b/dropbox/common/types.go
@@ -24,7 +24,7 @@ package common
 import (
 	"encoding/json"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
 )
 
 // PathRoot : has no documentation (yet)

--- a/dropbox/team/types.go
+++ b/dropbox/team/types.go
@@ -25,11 +25,11 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_common"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_policies"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/users"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/files"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_common"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_policies"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/users"
 )
 
 // DeviceSession : has no documentation (yet)

--- a/dropbox/team_common/types.go
+++ b/dropbox/team_common/types.go
@@ -24,7 +24,7 @@ package team_common
 import (
 	"time"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
 )
 
 // GroupManagementType : The group type determines how a group is managed.

--- a/dropbox/team_log/types.go
+++ b/dropbox/team_log/types.go
@@ -25,12 +25,12 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/sharing"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_common"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_policies"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/files"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/sharing"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_common"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_policies"
 )
 
 // AccessMethodLogInfo : Indicates the method in which the action was performed.
@@ -14459,7 +14459,7 @@ type SharedContentCopyDetails struct {
 	// SharedContentLink : Shared content link.
 	SharedContentLink string `json:"shared_content_link"`
 	// SharedContentOwner : The shared content owner.
-	SharedContentOwner IsUserLogInfo `json:"shared_content_owner,omitempty"`
+	SharedContentOwner UserLogInfo `json:"shared_content_owner,omitempty"`
 	// SharedContentAccessLevel : Shared content access level.
 	SharedContentAccessLevel *sharing.AccessLevel `json:"shared_content_access_level"`
 	// DestinationPath : The path where the member saved the content.
@@ -14493,7 +14493,7 @@ type SharedContentDownloadDetails struct {
 	// SharedContentLink : Shared content link.
 	SharedContentLink string `json:"shared_content_link"`
 	// SharedContentOwner : The shared content owner.
-	SharedContentOwner IsUserLogInfo `json:"shared_content_owner,omitempty"`
+	SharedContentOwner UserLogInfo `json:"shared_content_owner,omitempty"`
 	// SharedContentAccessLevel : Shared content access level.
 	SharedContentAccessLevel *sharing.AccessLevel `json:"shared_content_access_level"`
 }
@@ -14700,7 +14700,7 @@ type SharedContentViewDetails struct {
 	// SharedContentLink : Shared content link.
 	SharedContentLink string `json:"shared_content_link"`
 	// SharedContentOwner : The shared content owner.
-	SharedContentOwner IsUserLogInfo `json:"shared_content_owner,omitempty"`
+	SharedContentOwner UserLogInfo `json:"shared_content_owner,omitempty"`
 	// SharedContentAccessLevel : Shared content access level.
 	SharedContentAccessLevel *sharing.AccessLevel `json:"shared_content_access_level"`
 }
@@ -15115,7 +15115,7 @@ func NewSharedLinkChangeVisibilityType(Description string) *SharedLinkChangeVisi
 type SharedLinkCopyDetails struct {
 	// SharedLinkOwner : Shared link owner details. Might be missing due to
 	// historical data gap.
-	SharedLinkOwner IsUserLogInfo `json:"shared_link_owner,omitempty"`
+	SharedLinkOwner UserLogInfo `json:"shared_link_owner,omitempty"`
 }
 
 // NewSharedLinkCopyDetails returns a new SharedLinkCopyDetails instance
@@ -15167,7 +15167,7 @@ func NewSharedLinkCreateType(Description string) *SharedLinkCreateType {
 type SharedLinkDisableDetails struct {
 	// SharedLinkOwner : Shared link owner details. Might be missing due to
 	// historical data gap.
-	SharedLinkOwner IsUserLogInfo `json:"shared_link_owner,omitempty"`
+	SharedLinkOwner UserLogInfo `json:"shared_link_owner,omitempty"`
 }
 
 // NewSharedLinkDisableDetails returns a new SharedLinkDisableDetails instance
@@ -15193,7 +15193,7 @@ func NewSharedLinkDisableType(Description string) *SharedLinkDisableType {
 type SharedLinkDownloadDetails struct {
 	// SharedLinkOwner : Shared link owner details. Might be missing due to
 	// historical data gap.
-	SharedLinkOwner IsUserLogInfo `json:"shared_link_owner,omitempty"`
+	SharedLinkOwner UserLogInfo `json:"shared_link_owner,omitempty"`
 }
 
 // NewSharedLinkDownloadDetails returns a new SharedLinkDownloadDetails instance
@@ -15245,7 +15245,7 @@ func NewSharedLinkRemoveExpiryType(Description string) *SharedLinkRemoveExpiryTy
 type SharedLinkShareDetails struct {
 	// SharedLinkOwner : Shared link owner details. Might be missing due to
 	// historical data gap.
-	SharedLinkOwner IsUserLogInfo `json:"shared_link_owner,omitempty"`
+	SharedLinkOwner UserLogInfo `json:"shared_link_owner,omitempty"`
 	// ExternalUsers : Users without a Dropbox account that were added as shared
 	// link audience.
 	ExternalUsers []*ExternalUserLogInfo `json:"external_users,omitempty"`
@@ -15274,7 +15274,7 @@ func NewSharedLinkShareType(Description string) *SharedLinkShareType {
 type SharedLinkViewDetails struct {
 	// SharedLinkOwner : Shared link owner details. Might be missing due to
 	// historical data gap.
-	SharedLinkOwner IsUserLogInfo `json:"shared_link_owner,omitempty"`
+	SharedLinkOwner UserLogInfo `json:"shared_link_owner,omitempty"`
 }
 
 // NewSharedLinkViewDetails returns a new SharedLinkViewDetails instance

--- a/dropbox/users/client.go
+++ b/dropbox/users/client.go
@@ -26,7 +26,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
 )
 
 // Client interface describes all routes in this namespace

--- a/dropbox/users/types.go
+++ b/dropbox/users/types.go
@@ -25,8 +25,8 @@ package users
 import (
 	"encoding/json"
 
-	"github.com/drointello-iopbox/dropbox-sdk-go-unofficial/dropbox/common"
 	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/common"
 	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_common"
 	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_policies"
 	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/users_common"

--- a/dropbox/users/types.go
+++ b/dropbox/users/types.go
@@ -25,11 +25,11 @@ package users
 import (
 	"encoding/json"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/common"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_common"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/team_policies"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/users_common"
+	"github.com/drointello-iopbox/dropbox-sdk-go-unofficial/dropbox/common"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_common"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/team_policies"
+	"github.com/intello-io/dropbox-sdk-go-unofficial/dropbox/users_common"
 )
 
 // Account : The amount of detail revealed about an account depends on the user


### PR DESCRIPTION
 changing from isUserLogInfo to UserLogInfo   gets rid of JSON Unmarshal error: 
"json: cannot unmarshal " + e.Value + " into Go struct field " + e.Struct + "." + e.Field + " of type " + e.Type.String()"