### PR TITLE
Device link unmarshal

### DIFF
--- a/dropbox/team_log/types.go
+++ b/dropbox/team_log/types.go
@@ -1621,6 +1621,24 @@ func NewDeviceLinkSuccessDetails() *DeviceLinkSuccessDetails {
 	return s
 }
 
+// UnmarshalJSON deserializes into a DeviceLinkSuccessDetails instance
+func (u *DeviceLinkSuccessDetails) UnmarshalJSON(b []byte) error {
+	type wrap struct {
+		// DeviceSessionInfo : Device's session logged information
+		DeviceSessionInfo json.RawMessage `json:"device_session_info"`
+	}
+	var w wrap
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	DeviceSessionInfo, err := IsDeviceSessionLogInfoFromJSON(w.DeviceSessionInfo)
+	if err != nil {
+		return err
+	}
+	u.DeviceSessionInfo = DeviceSessionInfo
+	return nil
+}
+
 // DeviceLinkSuccessType : has no documentation (yet)
 type DeviceLinkSuccessType struct {
 	// Description : has no documentation (yet)

--- a/dropbox/team_log/types.go
+++ b/dropbox/team_log/types.go
@@ -1478,6 +1478,24 @@ func NewDeviceChangeIpMobileDetails() *DeviceChangeIpMobileDetails {
 	return s
 }
 
+// UnmarshalJSON deserializes into a DeviceChangeIpMobileDetails instance
+func (u *DeviceChangeIpMobileDetails) UnmarshalJSON(b []byte) error {
+	type wrap struct {
+		// DeviceSessionInfo : Device's session logged information.
+		DeviceSessionInfo json.RawMessage `json:"device_session_info"`
+	}
+	var w wrap
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	DeviceSessionInfo, err := IsDeviceSessionLogInfoFromJSON(w.DeviceSessionInfo)
+	if err != nil {
+		return err
+	}
+	u.DeviceSessionInfo = DeviceSessionInfo
+	return nil
+}
+
 // DeviceChangeIpMobileType : has no documentation (yet)
 type DeviceChangeIpMobileType struct {
 	// Description : has no documentation (yet)


### PR DESCRIPTION
This PR adds `UnmarshalJSON` methods to two types so that the `IsDeviceSessionLogInfo` type that they contain unmarshals correctly. Prior to the change, one of those types, `DeviceLinkSuccessDetails`, was failing to unmarshal. The `UnmarshalJSON` method added matches the one that exists for `DeviceChangeIpDesktopDetails`, which also contains the `IsDeviceSessionLogInfo` subtype and appears to have had the `Unmarhsal` function implemented correctly. 