### PR TITLE
Change IsLogInfo to LogInfo types

### DIFF
--- a/dropbox/team_log/types.go
+++ b/dropbox/team_log/types.go
@@ -1541,7 +1541,7 @@ func NewDeviceChangeIpWebType(Description string) *DeviceChangeIpWebType {
 type DeviceDeleteOnUnlinkFailDetails struct {
 	// SessionInfo : Session unique id. Might be missing due to historical data
 	// gap.
-	SessionInfo IsSessionLogInfo `json:"session_info,omitempty"`
+	SessionInfo SessionLogInfo `json:"session_info,omitempty"`
 	// DisplayName : The device name. Might be missing due to historical data
 	// gap.
 	DisplayName string `json:"display_name,omitempty"`
@@ -1573,7 +1573,7 @@ func NewDeviceDeleteOnUnlinkFailType(Description string) *DeviceDeleteOnUnlinkFa
 type DeviceDeleteOnUnlinkSuccessDetails struct {
 	// SessionInfo : Session unique id. Might be missing due to historical data
 	// gap.
-	SessionInfo IsSessionLogInfo `json:"session_info,omitempty"`
+	SessionInfo SessionLogInfo `json:"session_info,omitempty"`
 	// DisplayName : The device name. Might be missing due to historical data
 	// gap.
 	DisplayName string `json:"display_name,omitempty"`
@@ -1731,7 +1731,7 @@ const (
 // DeviceUnlinkDetails : Disconnected device.
 type DeviceUnlinkDetails struct {
 	// SessionInfo : Session unique id.
-	SessionInfo IsSessionLogInfo `json:"session_info,omitempty"`
+	SessionInfo SessionLogInfo `json:"session_info,omitempty"`
 	// DisplayName : The device name. Might be missing due to historical data
 	// gap.
 	DisplayName string `json:"display_name,omitempty"`
@@ -11011,7 +11011,7 @@ type LegacyDeviceSessionLogInfo struct {
 	DeviceSessionLogInfo
 	// SessionInfo : Session unique id. Might be missing due to historical data
 	// gap.
-	SessionInfo IsSessionLogInfo `json:"session_info,omitempty"`
+	SessionInfo SessionLogInfo `json:"session_info,omitempty"`
 	// DisplayName : The device name. Might be missing due to historical data
 	// gap.
 	DisplayName string `json:"display_name,omitempty"`


### PR DESCRIPTION
This PR changes the `IsSessionLogInfo` type to `SessionLogInfo` for all types that contain a field of that type and that do not also contain an `UnmarshalJSON` function to handle unmarshaling into an `IsSessionLogInfo` type. I also looked for other `Is*LogInfo` types that could fail for the same reason, but this looks like the only one remaining (we changed `IsUserLogInfo` fields in a separate PR).